### PR TITLE
Add ability to support exporting layout as JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,15 @@ proto.shot = function( opts, next ){
         return b64Img;
       case 'stream':
         return getStream( b64Img ).pipe( base64.decode() );
+      case 'json':
+        return page.evaluate(function(s) {
+          var eles = cy.elements();
+          var arr = [];
+          for( var i = 0; i < eles.length; i++ ){
+              arr.push(eles[i].position());
+          }
+          return arr;
+        }, 'title');
       default:
         throw new Exception('Invalid resolve type specified: ' + opts.resolvesTo);
     }

--- a/test/output-file.js
+++ b/test/output-file.js
@@ -131,6 +131,40 @@ describe('Output', function(){
     }).then( done );
   });
 
+
+  it('should exist (json)', function( done ){
+    snap.shot({
+      elements: [
+        {
+          data: { id: 'foo' }
+        },
+        {
+          data: { id: 'bar' }
+        },
+        {
+          data: { source: 'foo', target: 'bar' }
+        }
+      ],
+      format: 'png',
+      width: 1000,
+      height: 1000,
+      resolvesTo: 'json'
+    }).then(function( img ){
+      expect( img ).to.exist;
+      return img;
+    }).then(function( img ){
+      // put the image in the fs for manual verification
+      return new Promise(function( resolve ){
+        var out = require('fs').createWriteStream('./test/out.json');
+
+        out.write(JSON.stringify(img));
+
+        resolve();
+      });
+    }).then( done );
+  });
+
+
   it('should exist (png w/ large no. of eles)', function( done ){
     snap.shot({
       elements: (function(){
@@ -168,6 +202,8 @@ describe('Output', function(){
     }).then( done );
   });
 
+
+
   it('should be a png when so specified', function( done ){
     snap.shot({
       format: 'png',
@@ -185,4 +221,6 @@ describe('Output', function(){
       expect( img.indexOf('image/jpeg') ).to.be.at.least(0);
     }).then( done );
   });
+
+
 });


### PR DESCRIPTION
This PR attempts to add a "resolveTo: 'json'" to allow getting the final layout of a graph as JSON

Exporting as an image is quite nice, however, I would propose that re-exporting the layout as JSON is useful too, since then you could re-import this data and browse it interactively.

This may have a couple caveats still such as only outputting json after the it tries to render the page as an image, but I figured that it is a start to the idea!
